### PR TITLE
Improve VPN menu logging

### DIFF
--- a/vpn_menu.sh
+++ b/vpn_menu.sh
@@ -5,6 +5,7 @@
 
 GREEN="\033[0;32m"
 RED="\033[0;31m"
+BLUE="\033[0;34m"
 NC="\033[0m"
 
 CONFIG_DIR="/usr/local/etc/xray"
@@ -12,8 +13,21 @@ CONFIG_PATH="$CONFIG_DIR/config.json"
 RULE_COMMENT="VPN_MENU_RULE"
 TUN_PORT=1090
 
+log_msg() {
+    local level=$1
+    shift
+    local color
+    case $level in
+        INFO) color=$BLUE ;;
+        SUCCESS) color=$GREEN ;;
+        ERROR) color=$RED ;;
+        *) color=$NC ;;
+    esac
+    echo -e "${color}[$level]${NC} $*"
+}
+
 status_circle() {
-    if iptables -t nat -C OUTPUT -m comment --comment "$RULE_COMMENT" -j REDIRECT --to-ports "$TUN_PORT" 2>/dev/null; then
+    if iptables -t nat -C OUTPUT -m comment --comment "$RULE_COMMENT" -j REDIRECT --to-ports "$TUN_PORT"; then
         echo -e "${GREEN}●${NC}"
     else
         echo -e "${RED}●${NC}"
@@ -21,22 +35,27 @@ status_circle() {
 }
 
 install_xray() {
-    echo -e "${GREEN}Installing xray-core...${NC}"
+    log_msg INFO "Installing xray-core..."
     url=$(curl -s https://api.github.com/repos/XTLS/Xray-core/releases/latest \
         | grep browser_download_url \
         | grep 'Xray-linux-64\.zip' \
         | head -n 1 \
         | cut -d '"' -f 4)
     if [ -z "$url" ]; then
-        echo "Could not determine download URL."
+        log_msg ERROR "Could not determine download URL."
         return 1
     fi
     tmpdir=$(mktemp -d)
-    curl -L "$url" -o "$tmpdir/xray.zip"
-    unzip -q "$tmpdir/xray.zip" -d "$tmpdir"
-    sudo install -m 755 "$tmpdir/xray" /usr/local/bin/xray
-    rm -rf "$tmpdir"
-    echo "xray-core installed to /usr/local/bin/xray"
+    if output=$(curl -L "$url" -o "$tmpdir/xray.zip" 2>&1 && \
+        unzip -q "$tmpdir/xray.zip" -d "$tmpdir" 2>&1 && \
+        sudo install -m 755 "$tmpdir/xray" /usr/local/bin/xray 2>&1); then
+        rm -rf "$tmpdir"
+        log_msg SUCCESS "xray-core installed to /usr/local/bin/xray"
+    else
+        rm -rf "$tmpdir"
+        log_msg ERROR "Installation failed: $output"
+        return 1
+    fi
 }
 
 set_config() {
@@ -51,16 +70,48 @@ set_config() {
 }
 
 activate_vpn() {
-    echo -e "${GREEN}Activating VPN...${NC}"
-    sudo systemctl start xray >/dev/null 2>&1 || sudo xray -config "$CONFIG_PATH" &
-    sudo iptables -t nat -C OUTPUT -m comment --comment "$RULE_COMMENT" -j REDIRECT --to-ports "$TUN_PORT" 2>/dev/null || \
-    sudo iptables -t nat -A OUTPUT -p tcp -m comment --comment "$RULE_COMMENT" -j REDIRECT --to-ports "$TUN_PORT"
+    log_msg INFO "Activating VPN..."
+    if output=$(sudo systemctl start xray 2>&1); then
+        log_msg SUCCESS "xray service started"
+    else
+        if output=$(sudo xray -config "$CONFIG_PATH" 2>&1 &); then
+            log_msg SUCCESS "xray started"
+        else
+            log_msg ERROR "Failed to start xray: $output"
+            return 1
+        fi
+    fi
+
+    if sudo iptables -t nat -C OUTPUT -m comment --comment "$RULE_COMMENT" -j REDIRECT --to-ports "$TUN_PORT" 2>&1; then
+        log_msg INFO "iptables rule already exists"
+    else
+        if output=$(sudo iptables -t nat -A OUTPUT -p tcp -m comment --comment "$RULE_COMMENT" -j REDIRECT --to-ports "$TUN_PORT" 2>&1); then
+            log_msg SUCCESS "iptables rule added"
+        else
+            log_msg ERROR "Failed to add iptables rule: $output"
+            return 1
+        fi
+    fi
 }
 
 deactivate_vpn() {
-    echo -e "${RED}Deactivating VPN...${NC}"
-    sudo iptables -t nat -D OUTPUT -p tcp -m comment --comment "$RULE_COMMENT" -j REDIRECT --to-ports "$TUN_PORT" 2>/dev/null
-    sudo systemctl stop xray >/dev/null 2>&1 || sudo pkill -f "xray -config" >/dev/null 2>&1
+    log_msg INFO "Deactivating VPN..."
+    if output=$(sudo iptables -t nat -D OUTPUT -p tcp -m comment --comment "$RULE_COMMENT" -j REDIRECT --to-ports "$TUN_PORT" 2>&1); then
+        log_msg SUCCESS "iptables rule removed"
+    else
+        log_msg ERROR "Failed to remove iptables rule: $output"
+    fi
+
+    if output=$(sudo systemctl stop xray 2>&1); then
+        log_msg SUCCESS "xray service stopped"
+    else
+        if output=$(sudo pkill -f "xray -config" 2>&1); then
+            log_msg SUCCESS "xray process stopped"
+        else
+            log_msg ERROR "Failed to stop xray: $output"
+            return 1
+        fi
+    fi
 }
 
 test_ip() {


### PR DESCRIPTION
## Summary
- show colored INFO/SUCCESS/ERROR messages via new `log_msg` helper
- capture output from `install_xray`, `activate_vpn` and `deactivate_vpn`
- stop suppressing stderr output so issues are visible

## Testing
- `shellcheck vpn_menu.sh`

------
https://chatgpt.com/codex/tasks/task_b_6887923fa51883298ece34bcbdd314cf