### PR TITLE
Add log viewer to VPN menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,18 @@ cd tun-main
    ```
 
 3. Follow the on-screen menu to install xray, provide your configuration,
-   activate or deactivate routing, test your external IP, or toggle screen
-   clearing if you want to keep previous log output visible.
+   activate or deactivate routing, test your external IP, view recent xray
+   logs, or toggle screen clearing if you want to keep previous output visible.
 
 The menu displays a colored status indicator: **green** when the
 VPN rules are active and **red** when they are not.
+
+## Checking Logs
+
+Select "View logs" from the menu to display the last 20 lines from the xray
+service. The script will try to read `/var/log/xray/` if it exists, otherwise it
+falls back to `journalctl`:
+
+```bash
+sudo journalctl -u xray -n 20 --no-pager
+```

--- a/vpn_menu.sh
+++ b/vpn_menu.sh
@@ -132,6 +132,15 @@ toggle_clear() {
     fi
 }
 
+show_logs() {
+    log_msg INFO "Displaying xray logs..."
+    if [ -d /var/log/xray ]; then
+        sudo tail -n 20 /var/log/xray/* 2>/dev/null
+    else
+        sudo journalctl -u xray -n 20 --no-pager
+    fi
+}
+
 menu() {
     while true; do
         if [ "$CLEAR_SCREEN" -eq 1 ]; then
@@ -148,6 +157,7 @@ menu() {
         echo "4) Deactivate routing"
         echo "5) Test IP address"
         echo "6) Toggle screen clearing"
+        echo "7) View logs"
         echo "0) Exit"
         read -rp "Choice: " choice
         case $choice in
@@ -157,6 +167,7 @@ menu() {
             4) deactivate_vpn ;;
             5) test_ip ;;
             6) toggle_clear ;;
+            7) show_logs ;;
             0) exit 0 ;;
             *) echo "Invalid option" ;;
         esac


### PR DESCRIPTION
## Summary
- show xray logs with `journalctl` or `/var/log/xray`
- offer new "View logs" option in the menu
- mention log viewing in README

## Testing
- `shellcheck vpn_menu.sh`

------
https://chatgpt.com/codex/tasks/task_b_688795c8094c83298b0a6b2335c252d6